### PR TITLE
Handle multiple key handles in SignRequest

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -15,10 +15,15 @@ import (
 )
 
 // SignRequest creates a request to initiate an authentication.
-func (c *Challenge) SignRequest(reg Registration) *SignRequest {
+func (c *Challenge) SignRequest(regs ...Registration) *SignRequest {
+	var encodedHandles = make([]string, len(regs), len(regs))
+	for i, r := range regs {
+		encodedHandles[i] = encodeBase64(r.KeyHandle)
+	}
+
 	var sr SignRequest
 	sr.Version = u2fVersion
-	sr.KeyHandle = encodeBase64(reg.KeyHandle)
+	sr.KeyHandles = encodedHandles
 	sr.AppID = c.AppID
 	sr.Challenge = encodeBase64(c.Challenge)
 	return &sr

--- a/messages.go
+++ b/messages.go
@@ -41,10 +41,10 @@ type RegisterResponse struct {
 
 // SignRequest as defined by the FIDO U2F Javascript API.
 type SignRequest struct {
-	Version   string `json:"version"`
-	Challenge string `json:"challenge"`
-	KeyHandle string `json:"keyHandle"`
-	AppID     string `json:"appId"`
+	Version    string   `json:"version"`
+	Challenge  string   `json:"challenge"`
+	KeyHandles []string `json:"keyHandles"`
+	AppID      string   `json:"appId"`
 }
 
 // SignResponse as defined by the FIDO U2F Javascript API.


### PR DESCRIPTION
* Modify SignRequest to take multiple key handles rather than returning
  an array of SignRequests. This makes it easier to work with multiple
  registrations and the user doesn't have to pluck out the AppID,
  Version, and Challenge from the first SignRequest.
* Udate u2fdemo to work with new api

