### PR TITLE
add go.mod, allow overriding rand.Reader and time.Now

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,6 @@ import (
 	"encoding/asn1"
 	"errors"
 	"math/big"
-	"time"
 )
 
 // SignRequest creates a request to initiate an authentication.
@@ -37,8 +36,8 @@ var ErrCounterTooLow = errors.New("u2f: counter too low")
 // The counter should be the counter associated with appropriate device
 // (i.e. resp.KeyHandle).
 // The latest counter value is returned, which the caller should store.
-func (reg *Registration) Authenticate(resp SignResponse, c Challenge, counter uint32) (newCounter uint32, err error) {
-	if time.Now().Sub(c.Timestamp) > timeout {
+func (reg *Registration) Authenticate(resp SignResponse, c Challenge, counter uint32, config *Config) (newCounter uint32, err error) {
+	if config.timeNow().Sub(c.Timestamp) > timeout {
 		return 0, errors.New("u2f: challenge has expired")
 	}
 	if resp.KeyHandle != encodeBase64(reg.KeyHandle) {

--- a/auth.go
+++ b/auth.go
@@ -36,7 +36,13 @@ var ErrCounterTooLow = errors.New("u2f: counter too low")
 // The counter should be the counter associated with appropriate device
 // (i.e. resp.KeyHandle).
 // The latest counter value is returned, which the caller should store.
-func (reg *Registration) Authenticate(resp SignResponse, c Challenge, counter uint32, config *Config) (newCounter uint32, err error) {
+func (reg *Registration) Authenticate(resp SignResponse, c Challenge, counter uint32) (newCounter uint32, err error) {
+	return reg.AuthenticateConfig(resp, c, counter, nil)
+}
+
+// AuthenticateConfig is a variant of Authenticate where config.Time is used if
+// set.
+func (reg *Registration) AuthenticateConfig(resp SignResponse, c Challenge, counter uint32, config *Config) (newCounter uint32, err error) {
 	if config.timeNow().Sub(c.Timestamp) > timeout {
 		return 0, errors.New("u2f: challenge has expired")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tstranex/u2f
+
+go 1.14

--- a/u2f_test.go
+++ b/u2f_test.go
@@ -6,59 +6,83 @@
 package u2f
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
 
 func TestFull(t *testing.T) {
-	// These are actual responses from a Yubikey with Chrome.
+	testFunc := func(t *testing.T, nilConfig bool) {
+		// These are actual responses from a Yubikey with Chrome.
 
-	const appID = "http://localhost:3483"
+		const appID = "http://localhost:3483"
 
-	c1, _ := decodeBase64("s4UJ3wkN80p4wLjyI2Guv-_a-s7LV54Ic9PAZvHo_lM")
-	registerChallenge := Challenge{
-		Challenge:     c1,
-		Timestamp:     time.Now().Add(-time.Minute),
-		AppID:         appID,
-		TrustedFacets: []string{appID},
+		timeNow := time.Now()
+
+		var config *Config
+		if !nilConfig {
+			config = &Config{
+				Time: func() time.Time { return timeNow },
+			}
+		}
+
+		challengeConfig := func(cenc string) *Config {
+			c, err := decodeBase64(cenc)
+			if err != nil {
+				panic(err)
+			}
+			return &Config{
+				Rand: bytes.NewBuffer(c),
+				Time: func() time.Time { return timeNow.Add(-time.Minute) },
+			}
+		}
+
+		registerChallenge, err := NewChallenge(appID, []string{appID}, challengeConfig("s4UJ3wkN80p4wLjyI2Guv-_a-s7LV54Ic9PAZvHo_lM"))
+		if err != nil {
+			t.Error(err)
+		}
+
+		const regRespJSON = "{\"registrationData\":\"BQTD17IP7bZ3Gcd7l5Ao4qqohsUcm0bcXgHLpn0pv2VWNl7SBtNFo0wEoAdMrHlFXGzJgQz_bRZaKXZfHyd3fAo0QJmZkSv9ZbTKz7TVO6jnOcKGrSHb15JDatMMFxHxN5BR56CE3sj10jtGOY7szQIi4RGU6kONIuriAarxuEFJ5IswggIcMIIBBqADAgECAgQk26tAMAsGCSqGSIb3DQEBCzAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowKzEpMCcGA1UEAwwgWXViaWNvIFUyRiBFRSBTZXJpYWwgMTM1MDMyNzc4ODgwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQCsJS-NH1HeUHEd46-xcpN7SpHn6oeb-w5r-veDCBwy1vUvWnJanjjv4dR_rV5G436ysKUAXUcsVe5fAnkORo2oxIwEDAOBgorBgEEAYLECgEBBAAwCwYJKoZIhvcNAQELA4IBAQCjY64OmDrzC7rxLIst81pZvxy7ShsPy2jEhFWEkPaHNFhluNsCacNG5VOITCxWB68OonuQrIzx70MfcqwYnbIcgkkUvxeIpVEaM9B7TI40ZHzp9h4VFqmps26QCkAgYfaapG4SxTK5k_lCPvqqTPmjtlS03d7ykkpUj9WZlVEN1Pf02aTVIZOHPHHJuH6GhT6eLadejwxtKDBTdNTv3V4UlvjDOQYQe9aL1jUNqtLDeBHso8pDvJMLc0CX3vadaI2UVQxM-xip4kuGouXYj0mYmaCbzluBDFNsrzkNyL3elg3zMMrKvAUhoYMjlX_-vKWcqQsgsQ0JtSMcWMJ-umeDMEQCIApTYovLr8citOpIKkyNidCQz7UeSOWNMlPBB-s3r4G9AiAskXkh7iale4QDe6a-675L3xzohYb8Fcvz3gH6dkDLvw\",\"version\":\"U2F_V2\",\"challenge\":\"s4UJ3wkN80p4wLjyI2Guv-_a-s7LV54Ic9PAZvHo_lM\",\"appId\":\"http://localhost:3483\",\"clientData\":\"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZmluaXNoRW5yb2xsbWVudCIsImNoYWxsZW5nZSI6InM0VUozd2tOODBwNHdManlJMkd1di1fYS1zN0xWNTRJYzlQQVp2SG9fbE0iLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjM0ODMiLCJjaWRfcHVia2V5IjoiIn0\"}"
+		var regResp RegisterResponse
+		if err := json.Unmarshal([]byte(regRespJSON), &regResp); err != nil {
+			t.Error(err)
+		}
+
+		reg, err := Register(regResp, *registerChallenge, config)
+		if err != nil {
+			t.Error(err)
+		}
+
+		authChallenge, err := NewChallenge(appID, []string{appID}, challengeConfig("PzN6SGiUaeypErE3SCHeRlkRxVwfWlGVi35gfq6LsdY"))
+		if err != nil {
+			t.Error(err)
+		}
+
+		const signRespJSON = "{\"keyHandle\":\"mZmRK_1ltMrPtNU7qOc5woatIdvXkkNq0wwXEfE3kFHnoITeyPXSO0Y5juzNAiLhEZTqQ40i6uIBqvG4QUnkiw\",\"clientData\":\"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiUHpONlNHaVVhZXlwRXJFM1NDSGVSbGtSeFZ3ZldsR1ZpMzVnZnE2THNkWSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzQ4MyIsImNpZF9wdWJrZXkiOiIifQ\",\"signatureData\":\"AQAAAAYwRAIgBuyafOXoc9Q7fARcs2JbCZdtnMzVCyeJC-J-2Im1IBsCIDxkzmvPX9RCY8uts4wM1y4wEX9LmNH2Mz_VFd-JdyGE\"}"
+		var signResp SignResponse
+		if err := json.Unmarshal([]byte(signRespJSON), &signResp); err != nil {
+			t.Error(err)
+		}
+
+		newCounter, err := reg.Authenticate(signResp, *authChallenge, 0, config)
+		if err != nil {
+			t.Error(err)
+		}
+		if newCounter != 6 {
+			t.Errorf("Wrong new counter: %d", newCounter)
+		}
+
+		newCounter, err = reg.Authenticate(signResp, *authChallenge, 7, config)
+		if err == nil {
+			t.Errorf("Expected error due to decreasing counter")
+		}
 	}
 
-	const regRespJSON = "{\"registrationData\":\"BQTD17IP7bZ3Gcd7l5Ao4qqohsUcm0bcXgHLpn0pv2VWNl7SBtNFo0wEoAdMrHlFXGzJgQz_bRZaKXZfHyd3fAo0QJmZkSv9ZbTKz7TVO6jnOcKGrSHb15JDatMMFxHxN5BR56CE3sj10jtGOY7szQIi4RGU6kONIuriAarxuEFJ5IswggIcMIIBBqADAgECAgQk26tAMAsGCSqGSIb3DQEBCzAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowKzEpMCcGA1UEAwwgWXViaWNvIFUyRiBFRSBTZXJpYWwgMTM1MDMyNzc4ODgwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQCsJS-NH1HeUHEd46-xcpN7SpHn6oeb-w5r-veDCBwy1vUvWnJanjjv4dR_rV5G436ysKUAXUcsVe5fAnkORo2oxIwEDAOBgorBgEEAYLECgEBBAAwCwYJKoZIhvcNAQELA4IBAQCjY64OmDrzC7rxLIst81pZvxy7ShsPy2jEhFWEkPaHNFhluNsCacNG5VOITCxWB68OonuQrIzx70MfcqwYnbIcgkkUvxeIpVEaM9B7TI40ZHzp9h4VFqmps26QCkAgYfaapG4SxTK5k_lCPvqqTPmjtlS03d7ykkpUj9WZlVEN1Pf02aTVIZOHPHHJuH6GhT6eLadejwxtKDBTdNTv3V4UlvjDOQYQe9aL1jUNqtLDeBHso8pDvJMLc0CX3vadaI2UVQxM-xip4kuGouXYj0mYmaCbzluBDFNsrzkNyL3elg3zMMrKvAUhoYMjlX_-vKWcqQsgsQ0JtSMcWMJ-umeDMEQCIApTYovLr8citOpIKkyNidCQz7UeSOWNMlPBB-s3r4G9AiAskXkh7iale4QDe6a-675L3xzohYb8Fcvz3gH6dkDLvw\",\"version\":\"U2F_V2\",\"challenge\":\"s4UJ3wkN80p4wLjyI2Guv-_a-s7LV54Ic9PAZvHo_lM\",\"appId\":\"http://localhost:3483\",\"clientData\":\"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZmluaXNoRW5yb2xsbWVudCIsImNoYWxsZW5nZSI6InM0VUozd2tOODBwNHdManlJMkd1di1fYS1zN0xWNTRJYzlQQVp2SG9fbE0iLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjM0ODMiLCJjaWRfcHVia2V5IjoiIn0\"}"
-	var regResp RegisterResponse
-	if err := json.Unmarshal([]byte(regRespJSON), &regResp); err != nil {
-		t.Error(err)
-	}
-
-	reg, err := Register(regResp, registerChallenge, nil)
-	if err != nil {
-		t.Error(err)
-	}
-
-	c2, _ := decodeBase64("PzN6SGiUaeypErE3SCHeRlkRxVwfWlGVi35gfq6LsdY")
-	authChallenge := Challenge{
-		Challenge:     c2,
-		Timestamp:     time.Now().Add(-time.Minute),
-		AppID:         appID,
-		TrustedFacets: []string{appID},
-	}
-
-	const signRespJSON = "{\"keyHandle\":\"mZmRK_1ltMrPtNU7qOc5woatIdvXkkNq0wwXEfE3kFHnoITeyPXSO0Y5juzNAiLhEZTqQ40i6uIBqvG4QUnkiw\",\"clientData\":\"eyJ0eXAiOiJuYXZpZ2F0b3IuaWQuZ2V0QXNzZXJ0aW9uIiwiY2hhbGxlbmdlIjoiUHpONlNHaVVhZXlwRXJFM1NDSGVSbGtSeFZ3ZldsR1ZpMzVnZnE2THNkWSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzQ4MyIsImNpZF9wdWJrZXkiOiIifQ\",\"signatureData\":\"AQAAAAYwRAIgBuyafOXoc9Q7fARcs2JbCZdtnMzVCyeJC-J-2Im1IBsCIDxkzmvPX9RCY8uts4wM1y4wEX9LmNH2Mz_VFd-JdyGE\"}"
-	var signResp SignResponse
-	if err := json.Unmarshal([]byte(signRespJSON), &signResp); err != nil {
-		t.Error(err)
-	}
-
-	newCounter, err := reg.Authenticate(signResp, authChallenge, 0)
-	if err != nil {
-		t.Error(err)
-	}
-	if newCounter != 6 {
-		t.Errorf("Wrong new counter: %d", newCounter)
-	}
-
-	newCounter, err = reg.Authenticate(signResp, authChallenge, 7)
-	if err == nil {
-		t.Errorf("Expected error due to decreasing counter")
+	for _, nilConfig := range []bool{true, false} {
+		t.Run(fmt.Sprintf("nilConfig=%v", nilConfig), func(t *testing.T) {
+			testFunc(t, nilConfig)
+		})
 	}
 }

--- a/util.go
+++ b/util.go
@@ -79,7 +79,13 @@ type Challenge struct {
 }
 
 // NewChallenge generates a challenge for the given application.
-func NewChallenge(appID string, trustedFacets []string, config *Config) (*Challenge, error) {
+func NewChallenge(appID string, trustedFacets []string) (*Challenge, error) {
+	return NewChallengeConfig(appID, trustedFacets, nil)
+}
+
+// NewChallengeConfig is a variant of NewChallenge where config.Rand and
+// config.Time are used if set.
+func NewChallengeConfig(appID string, trustedFacets []string, config *Config) (*Challenge, error) {
 	challenge := make([]byte, 32)
 	n, err := config.randRead(challenge)
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -46,7 +46,6 @@ https://fidoalliance.org/specifications/download
 package u2f
 
 import (
-	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
@@ -80,9 +79,9 @@ type Challenge struct {
 }
 
 // NewChallenge generates a challenge for the given application.
-func NewChallenge(appID string, trustedFacets []string) (*Challenge, error) {
+func NewChallenge(appID string, trustedFacets []string, config *Config) (*Challenge, error) {
 	challenge := make([]byte, 32)
-	n, err := rand.Read(challenge)
+	n, err := config.randRead(challenge)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +91,7 @@ func NewChallenge(appID string, trustedFacets []string) (*Challenge, error) {
 
 	var c Challenge
 	c.Challenge = challenge
-	c.Timestamp = time.Now()
+	c.Timestamp = config.timeNow()
 	c.AppID = appID
 	c.TrustedFacets = trustedFacets
 	return &c, nil


### PR DESCRIPTION
**add go.mod**

A basic go.mod file with go 1.14 requirement (N-3 at the moment). It could be older or newer if you wish.

**allow overriding rand.Reader and time.Now** and **make Registration.Authenticate and NewChallenge backward compatible**

We run u2f in a special environment with a custom time provider, so it's a must for us. rand.Reader override makes tests a bit cleaner IMO. First commit adds Config in a clean but incompatible way. Second commit makes the changes backward compatible. I based the changes on https://github.com/tstranex/u2f/pull/13#issuecomment-386826012